### PR TITLE
Agent should failed on SocketNotFoundException #280

### DIFF
--- a/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
+++ b/src/main/java/org/ice4j/ice/ConnectivityCheckClient.java
@@ -344,6 +344,8 @@ class ConnectivityCheckClient
             {
                 logger.trace("checking pair " + candidatePair + " tid " + tran);
             }
+
+            return tran;
         }
         catch (NetAccessManager.SocketNotFoundException e)
         {
@@ -351,8 +353,6 @@ class ConnectivityCheckClient
         }
         catch (Exception ex)
         {
-            tran = null;
-
             IceSocketWrapper stunSocket = localCandidate.getStunSocket(null);
 
             if (stunSocket != null)
@@ -376,7 +376,7 @@ class ConnectivityCheckClient
             }
         }
 
-        return tran;
+        return null;
     }
 
     /**
@@ -944,6 +944,7 @@ class ConnectivityCheckClient
                             "Pair failed: "
                                 + pairToCheck.toShortString());
                         pairToCheck.setStateFailed();
+                        updateCheckListAndTimerStates(pairToCheck);
                     }
                     else
                     {


### PR DESCRIPTION
If there are no matching candidate because a configuration mistake then the agent should failed.